### PR TITLE
Reduce try...catch scope to stop masking errors

### DIFF
--- a/marshmallow_polyfield/polyfield.py
+++ b/marshmallow_polyfield/polyfield.py
@@ -39,7 +39,7 @@ class PolyField(Field):
             schema = None
             try:
                 schema = self.deserialization_schema_selector(v, data)
-                data, errors = schema.load(v)
+                assert hasattr(schema, 'load')
             except Exception:
                 schema_message = None
                 if schema:
@@ -53,6 +53,7 @@ class PolyField(Field):
                         class_type=schema_message
                     )
                 )
+            data, errors = schema.load(v)
             if errors:
                 raise ValidationError(errors)
             results.append(data)

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ def read(fname):
 
 setup(
     name='marshmallow-polyfield',
-    version=2.7,
+    version=3.0,
     description='An unofficial extension to Marshmallow to allow for polymorphic fields',
     long_description=read('README.rst'),
     author='Matt Bachmann',


### PR DESCRIPTION
The try...catch block to detect invalid `deserialization_schema_selector` values is overly broad, and masks errors in the `schema.load` method, resulting in misleading exceptions. 

This patch reduces the scope of the try...catch block to only include the `deserialization_schema_selector` call.
