### PR TITLE
Update to marshmallow 3.0

### DIFF
--- a/marshmallow_polyfield/polyfield.py
+++ b/marshmallow_polyfield/polyfield.py
@@ -1,10 +1,4 @@
 from marshmallow import ValidationError
-try:
-    # UnmarshalResult not present in >=3.0.0, so use to flag marshmallow version
-    from marshmallow import UnmarshalResult  # NOQA
-    MARSHMALLOW_3 = False
-except ImportError:
-    MARSHMALLOW_3 = True
 from marshmallow.fields import Field
 
 

--- a/marshmallow_polyfield/polyfield.py
+++ b/marshmallow_polyfield/polyfield.py
@@ -99,7 +99,7 @@ class PolyField(Field):
             else:
                 schema = self.serialization_schema_selector(value, obj)
                 schema.context.update(getattr(self, 'context', {}))
-                dump_result = schema.dump(v)
+                dump_result = schema.dump(value)
                 if MARSHMALLOW_3:
                     return dump_result
                 else:

--- a/marshmallow_polyfield/polyfield.py
+++ b/marshmallow_polyfield/polyfield.py
@@ -62,15 +62,7 @@ class PolyField(Field):
             schema.context.update(getattr(self, 'context', {}))
 
             # Will raise ValidationError if any problems
-            load_result = schema.load(v)
-            if MARSHMALLOW_3:
-                data = load_result
-            else:
-                data, errors = load_result
-
-                if errors:
-                    raise ValidationError(errors)
-
+            data = schema.load(v)
             results.append(data)
 
         if self.many:
@@ -89,21 +81,14 @@ class PolyField(Field):
                     schema = self.serialization_schema_selector(v, obj)
                     schema.context.update(getattr(self, 'context', {}))
 
-                    dump_result = schema.dump(v)
+                    data = schema.dump(v)
 
-                    if MARSHMALLOW_3:
-                        res.append(dump_result)
-                    else:
-                        res.append(dump_result.data)
+                    res.append(data)
                 return res
             else:
                 schema = self.serialization_schema_selector(value, obj)
                 schema.context.update(getattr(self, 'context', {}))
-                dump_result = schema.dump(value)
-                if MARSHMALLOW_3:
-                    return dump_result
-                else:
-                    return dump_result.data
+                return schema.dump(value)
         except Exception as err:
             raise TypeError(
                 'Failed to serialize object. Error: {0}\n'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 coverage>=3.7.1
 coveralls>=0.5
 flake8>=2.4.1
-marshmallow>=2.0.0b5
+marshmallow>=3.0.0b10
 pytest>=2.7.2
 pytest-cov>=2.1.0
 tox>=2.1.1

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     license=read('LICENSE'),
     keywords=('serialization', 'rest', 'json', 'api', 'marshal',
               'marshalling', 'deserialization', 'validation', 'schema'),
-    install_requires=['marshmallow>=2.0.0'],
+    install_requires=['marshmallow>=3.0.0'],
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1,9 +1,4 @@
 from marshmallow import Schema, ValidationError, post_load, fields
-try:
-    from marshmallow import UnmarshalResult  # NOQA
-    MARSHMALLOW_3 = False
-except ImportError:
-    MARSHMALLOW_3 = True
 from marshmallow_polyfield.polyfield import PolyField
 import pytest
 from tests.shapes import (
@@ -69,7 +64,7 @@ class TestPolyField(object):
             [Rectangle('pink', 4, 93), Triangle('red', 8, 45)]
         )
 
-        load_result = self.ContrivedShapeClassSchema().load(
+        data = self.ContrivedShapeClassSchema().load(
             {'main': {'color': 'blue',
                       'length': 1,
                       'width': 100},
@@ -81,11 +76,6 @@ class TestPolyField(object):
                   'base': 8,
                   'height': 45}]}
         )
-        if MARSHMALLOW_3:
-            data = load_result
-        else:
-            data, errors = load_result
-
         assert data == original
 
     def test_deserialize_polyfield_none(self):
@@ -94,64 +84,42 @@ class TestPolyField(object):
             None
         )
 
-        load_result = self.ContrivedShapeClassSchema().load(
+        data = self.ContrivedShapeClassSchema().load(
             {'main': {'color': 'blue',
                       'length': 1,
                       'width': 100},
              'others': None}
         )
 
-        if MARSHMALLOW_3:
-            data = load_result
-        else:
-            data, errors = load_result
-
         assert data == original
 
     def test_deserailize_polyfield_none_required(self):
 
-        kwargs = {}
-        if not MARSHMALLOW_3:
-            kwargs = {'strict': True}
-
         with pytest.raises(ValidationError):
-            self.ContrivedShapeClassSchema(**kwargs).load(
+            self.ContrivedShapeClassSchema().load(
                 {'main': None,
                  'others': None}
             )
 
     def test_deserialize_polyfield_invalid(self):
-
-        kwargs = {}
-        if not MARSHMALLOW_3:
-            kwargs = {'strict': True}
-
         with pytest.raises(ValidationError):
-            self.ContrivedShapeClassSchema(**kwargs).load(
+            self.ContrivedShapeClassSchema().load(
                 {'main': {'color': 'blue', 'something': 4},
                  'others': None}
             )
 
     def test_deserialize_polyfield_invalid_schema_returned_is_invalid(self):
 
-        kwargs = {}
-        if not MARSHMALLOW_3:
-            kwargs = {'strict': True}
-
         with pytest.raises(ValidationError):
-            self.BadContrivedClassSchema(**kwargs).load(
+            self.BadContrivedClassSchema().load(
                 {'main': {'color': 'blue', 'something': 4},
                  'others': None}
             )
 
     def test_deserialize_polyfield_errors(self):
 
-        kwargs = {}
-        if not MARSHMALLOW_3:
-            kwargs = {'strict': True}
-
         with pytest.raises(ValidationError):
-            self.ContrivedShapeClassSchema(**kwargs).load(
+            self.ContrivedShapeClassSchema().load(
                 {'main': {'color': 'blue', 'length': 'four', 'width': 4},
                  'others': None}
             )
@@ -197,7 +165,7 @@ class TestPolyFieldDisambiguationByProperty(object):
             'rectangle'
         )
 
-        load_result = self.ContrivedShapeClassSchema().load(
+        data = self.ContrivedShapeClassSchema().load(
             {'main': {'color': 'blue',
                       'length': 1,
                       'width': 100},
@@ -206,10 +174,5 @@ class TestPolyFieldDisambiguationByProperty(object):
                          'width': 93}],
              'type': 'rectangle'}
         )
-
-        if MARSHMALLOW_3:
-            data = load_result
-        else:
-            data, errors = load_result
 
         assert data == original

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -64,7 +64,7 @@ class TestPolyField(object):
             [Rectangle('pink', 4, 93), Triangle('red', 8, 45)]
         )
 
-        data, errors = self.ContrivedShapeClassSchema(strict=True).load(
+        data = self.ContrivedShapeClassSchema().load(
             {'main': {'color': 'blue',
                       'length': 1,
                       'width': 100},
@@ -76,7 +76,6 @@ class TestPolyField(object):
                   'base': 8,
                   'height': 45}]}
         )
-        assert not errors
         assert data == original
 
     def test_deserialize_polyfield_none(self):
@@ -85,42 +84,41 @@ class TestPolyField(object):
             None
         )
 
-        data, errors = self.ContrivedShapeClassSchema(strict=True).load(
+        data = self.ContrivedShapeClassSchema().load(
             {'main': {'color': 'blue',
                       'length': 1,
                       'width': 100},
              'others': None}
         )
-        assert not errors
         assert data == original
 
     def test_deserailize_polyfield_none_required(self):
         with pytest.raises(ValidationError):
-            self.ContrivedShapeClassSchema(strict=True).load(
+            self.ContrivedShapeClassSchema().load(
                 {'main': None,
                  'others': None}
             )
 
     def test_deserialize_polyfield_invalid(self):
         with pytest.raises(ValidationError):
-            self.ContrivedShapeClassSchema(strict=True).load(
+            self.ContrivedShapeClassSchema().load(
                 {'main': {'color': 'blue', 'something': 4},
                  'others': None}
             )
 
     def test_deserialize_polyfield_invalid_schema_returned_is_invalid(self):
         with pytest.raises(ValidationError):
-            self.BadContrivedClassSchema(strict=True).load(
+            self.BadContrivedClassSchema().load(
                 {'main': {'color': 'blue', 'something': 4},
                  'others': None}
             )
 
     def test_deserialize_polyfield_errors(self):
-        data, errors = self.ContrivedShapeClassSchema().load(
-            {'main': {'color': 'blue', 'length': 'four', 'width': 4},
-             'others': None}
-        )
-        assert errors
+        with pytest.raises(ValidationError):
+            self.ContrivedShapeClassSchema().load(
+                {'main': {'color': 'blue', 'length': 'four', 'width': 4},
+                 'others': None}
+            )
 
 
 class TestPolyFieldDisambiguationByProperty(object):
@@ -163,7 +161,7 @@ class TestPolyFieldDisambiguationByProperty(object):
             'rectangle'
         )
 
-        data, errors = self.ContrivedShapeClassSchema(strict=True).load(
+        data = self.ContrivedShapeClassSchema().load(
             {'main': {'color': 'blue',
                       'length': 1,
                       'width': 100},
@@ -172,5 +170,4 @@ class TestPolyFieldDisambiguationByProperty(object):
                          'width': 93}],
              'type': 'rectangle'}
         )
-        assert not errors
         assert data == original

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,11 +1,5 @@
 from collections import namedtuple
 from marshmallow import fields, Schema
-try:
-    from marshmallow import UnmarshalResult  # NOQA
-    MARSHMALLOW_3 = False
-except ImportError:
-    MARSHMALLOW_3 = True
-
 from marshmallow_polyfield.polyfield import PolyField
 import pytest
 from tests.shapes import (
@@ -37,15 +31,8 @@ def test_serializing_named_tuple_with_meta():
             fields = ('x', 'y')
 
     serialized = PointSerializer().dump(p)
-    try:
-        assert serialized.data['x'] == 4
-    except AttributeError:
-        assert serialized['x'] == 4
-
-    try:
-        assert serialized.data['y'] == 2
-    except AttributeError:
-        assert serialized['y'] == 2
+    assert serialized['x'] == 4
+    assert serialized['y'] == 2
 
 
 def test_serializing_polyfield_rectangle():

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,5 +1,11 @@
 from collections import namedtuple
 from marshmallow import fields, Schema
+try:
+    from marshmallow import UnmarshalResult  # NOQA
+    MARSHMALLOW_3 = False
+except ImportError:
+    MARSHMALLOW_3 = True
+
 from marshmallow_polyfield.polyfield import PolyField
 import pytest
 from tests.shapes import (
@@ -31,8 +37,15 @@ def test_serializing_named_tuple_with_meta():
             fields = ('x', 'y')
 
     serialized = PointSerializer().dump(p)
-    assert serialized.data['x'] == 4
-    assert serialized.data['y'] == 2
+    try:
+        assert serialized.data['x'] == 4
+    except AttributeError:
+        assert serialized['x'] == 4
+
+    try:
+        assert serialized.data['y'] == 2
+    except AttributeError:
+        assert serialized['y'] == 2
 
 
 def test_serializing_polyfield_rectangle():


### PR DESCRIPTION
The marshmallow API has breaking changes in their 3.0 API, see 
http://marshmallow.readthedocs.io/en/latest/upgrading.html#upgrading-3-0

This PR incorporates those changes to make marshmallow-polyfield compatible with marshmallow>=3.0.0