### PR TITLE
Add PolyFieldBase abstract class

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,7 @@
 language: python
 sudo: false
 python:
-  - "3.4"
-  - "3.3"
+  - "3.6"
   - "2.7"
   - "pypy"
 

--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,6 @@ take in the raw value and return the schema to use.
 
 This field should support the same properties as other Marshmallow fields. I have worked with *required* *allow_none* and *many*.
 
-Last version support v2 is tagged FINAL_V2_VERSION
-
 Installing
 ----------
 ::

--- a/marshmallow_polyfield/__init__.py
+++ b/marshmallow_polyfield/__init__.py
@@ -1,1 +1,3 @@
-from marshmallow_polyfield.polyfield import PolyField, PolyFieldBase  # noqa
+from marshmallow_polyfield.polyfield import PolyField, PolyFieldBase
+
+__all__ = ['PolyField', 'PolyFieldBase']

--- a/marshmallow_polyfield/__init__.py
+++ b/marshmallow_polyfield/__init__.py
@@ -1,1 +1,1 @@
-from marshmallow_polyfield.polyfield import PolyField  # noqa
+from marshmallow_polyfield.polyfield import PolyField, PolyFieldBase  # noqa

--- a/marshmallow_polyfield/polyfield.py
+++ b/marshmallow_polyfield/polyfield.py
@@ -34,9 +34,9 @@ class PolyFieldBase(with_metaclass(abc.ABCMeta, Field)):
                     )
                 )
             schema.context.update(getattr(self, 'context', {}))
-
-            # Will raise ValidationError if any problems
-            data = schema.load(v)
+            data, errors = schema.load(v)
+            if errors:
+                raise ValidationError(errors)
             results.append(data)
 
         if self.many:
@@ -54,15 +54,12 @@ class PolyFieldBase(with_metaclass(abc.ABCMeta, Field)):
                 for v in value:
                     schema = self.serialization_schema_selector(v, obj)
                     schema.context.update(getattr(self, 'context', {}))
-
-                    data = schema.dump(v)
-
-                    res.append(data)
+                    res.append(schema.dump(v).data)
                 return res
             else:
                 schema = self.serialization_schema_selector(value, obj)
                 schema.context.update(getattr(self, 'context', {}))
-                return schema.dump(value)
+                return schema.dump(value).data
         except Exception as err:
             raise TypeError(
                 'Failed to serialize object. Error: {0}\n'

--- a/marshmallow_polyfield/polyfield.py
+++ b/marshmallow_polyfield/polyfield.py
@@ -68,12 +68,10 @@ class PolyFieldBase(with_metaclass(abc.ABCMeta, Field)):
                 ' can serialize this value {1}'.format(err, value))
 
     @abc.abstractmethod
-    def serialization_schema_selector(self, value, obj):
-        raise NotImplementedError
+    def serialization_schema_selector(self, value, obj): raise NotImplementedError
 
     @abc.abstractmethod
-    def deserialization_schema_selector(self, value, obj):
-        raise NotImplementedError
+    def deserialization_schema_selector(self, value, obj): raise NotImplementedError
 
 
 class PolyField(PolyFieldBase):

--- a/marshmallow_polyfield/polyfield.py
+++ b/marshmallow_polyfield/polyfield.py
@@ -68,10 +68,12 @@ class PolyFieldBase(with_metaclass(abc.ABCMeta, Field)):
                 ' can serialize this value {1}'.format(err, value))
 
     @abc.abstractmethod
-    def serialization_schema_selector(self, value, obj): raise NotImplementedError
+    def serialization_schema_selector(self, value, obj):
+        raise NotImplementedError
 
     @abc.abstractmethod
-    def deserialization_schema_selector(self, value, obj): raise NotImplementedError
+    def deserialization_schema_selector(self, value, obj):
+        raise NotImplementedError
 
 
 class PolyField(PolyFieldBase):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 coverage>=3.7.1
 coveralls>=0.5
 flake8>=2.4.1
-marshmallow>=2.0.0b5
+marshmallow~=2.0
 pytest>=2.7.2
 pytest-cov>=2.1.0
 tox>=2.1.1

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name='marshmallow-polyfield',
-    version=3.3,
+    version=4.1,
     description='An unofficial extension to Marshmallow to allow for polymorphic fields',
     long_description=read('README.rst'),
     author='Matt Bachmann',
@@ -26,11 +26,10 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Programming Language :: Python :: Implementation :: PyPy',
     ],

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name='marshmallow-polyfield',
-    version=3.2,
+    version=3.3,
     description='An unofficial extension to Marshmallow to allow for polymorphic fields',
     long_description=read('README.rst'),
     author='Matt Bachmann',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def read(fname):
 
 setup(
     name='marshmallow-polyfield',
-    version=4.1,
+    version=3.3,
     description='An unofficial extension to Marshmallow to allow for polymorphic fields',
     long_description=read('README.rst'),
     author='Matt Bachmann',

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     license=read('LICENSE'),
     keywords=('serialization', 'rest', 'json', 'api', 'marshal',
               'marshalling', 'deserialization', 'validation', 'schema'),
-    install_requires=['marshmallow>=2.0.0'],
+    install_requires=['marshmallow~=2.0', 'six'],
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',

--- a/tests/polyclasses.py
+++ b/tests/polyclasses.py
@@ -1,0 +1,35 @@
+from marshmallow_polyfield import PolyFieldBase
+
+from tests.shapes import (
+    shape_schema_serialization_disambiguation,
+    shape_property_schema_serialization_disambiguation,
+    shape_schema_deserialization_disambiguation,
+    shape_property_schema_deserialization_disambiguation
+)
+
+
+def with_all(*args):
+    def wrapper(func):
+        def wrapped(*args_):
+            return [
+                func(*(args_ + (a,)))
+                for a in args
+            ]
+        return wrapped
+    return wrapper
+
+
+class ShapePolyField(PolyFieldBase):
+    def serialization_schema_selector(self, value, obj):
+        return shape_schema_serialization_disambiguation(value, obj)
+
+    def deserialization_schema_selector(self, value, obj):
+        return shape_schema_deserialization_disambiguation(value, obj)
+
+
+class ShapePropertyPolyField(PolyFieldBase):
+    def serialization_schema_selector(self, value, obj):
+        return shape_property_schema_serialization_disambiguation(value, obj)
+
+    def deserialization_schema_selector(self, value, obj):
+        return shape_property_schema_deserialization_disambiguation(value, obj)

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -108,6 +108,7 @@ class TestPolyField(object):
                   'base': 8,
                   'height': 45}]}
         )
+        assert not errors
         assert data == original
 
     @with_all(
@@ -126,7 +127,7 @@ class TestPolyField(object):
                       'width': 100},
              'others': None}
         )
-
+        assert not errors
         assert data == original
 
     @with_all(
@@ -240,5 +241,5 @@ class TestPolyFieldDisambiguationByProperty(object):
                          'width': 93}],
              'type': 'rectangle'}
         )
-
+        assert not errors
         assert data == original

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -1,5 +1,5 @@
 from marshmallow import Schema, ValidationError, post_load, fields
-from marshmallow_polyfield.polyfield import PolyField
+from marshmallow_polyfield.polyfield import PolyField, PolyFieldBase
 import pytest
 from tests.shapes import (
     Rectangle,
@@ -9,10 +9,23 @@ from tests.shapes import (
     shape_schema_deserialization_disambiguation,
     shape_property_schema_deserialization_disambiguation
 )
+from tests.polyclasses import (
+    ShapePolyField,
+    ShapePropertyPolyField,
+    with_all
+)
 
 
 def _bad_deserializer_disambiguation(self, _):
         return 1
+
+
+class BadClassPolyField(PolyFieldBase):
+    def serialization_schema_selector(self, value, obj):
+        return _bad_deserializer_disambiguation(value, obj)
+
+    def deserialization_schema_selector(self, value, obj):
+        return _bad_deserializer_disambiguation(value, obj)
 
 
 class TestPolyField(object):
@@ -29,6 +42,10 @@ class TestPolyField(object):
             allow_none=True,
             many=True
         )
+
+    class BadContrivedSubclassSchema(Schema):
+        main = BadClassPolyField(required=True)
+        others = BadClassPolyField(allow_none=True, many=True)
 
     class ContrivedShapeClass(object):
         def __init__(self, main, others):
@@ -58,13 +75,28 @@ class TestPolyField(object):
                 data.get('others')
             )
 
-    def test_deserialize_polyfield(self):
+    class ContrivedShapeSubclassSchema(Schema):
+        main = ShapePolyField(required=True)
+        others = ShapePolyField(allow_none=True, many=True)
+
+        @post_load
+        def make_object(self, data):
+            return TestPolyField.ContrivedShapeClass(
+                data.get('main'),
+                data.get('others')
+            )
+
+    @with_all(
+        ContrivedShapeClassSchema,
+        ContrivedShapeSubclassSchema,
+    )
+    def test_deserialize_polyfield(self, schema):
         original = self.ContrivedShapeClass(
             Rectangle('blue', 1, 100),
             [Rectangle('pink', 4, 93), Triangle('red', 8, 45)]
         )
 
-        data, errors = self.ContrivedShapeClassSchema(strict=True).load(
+        data, errors = schema(strict=True).load(
             {'main': {'color': 'blue',
                       'length': 1,
                       'width': 100},
@@ -79,13 +111,17 @@ class TestPolyField(object):
         assert not errors
         assert data == original
 
-    def test_deserialize_polyfield_none(self):
+    @with_all(
+        ContrivedShapeClassSchema,
+        ContrivedShapeSubclassSchema,
+    )
+    def test_deserialize_polyfield_none(self, schema):
         original = self.ContrivedShapeClass(
             Rectangle("blue", 1, 100),
             None
         )
 
-        data, errors = self.ContrivedShapeClassSchema(strict=True).load(
+        data, errors = schema(strict=True).load(
             {'main': {'color': 'blue',
                       'length': 1,
                       'width': 100},
@@ -94,29 +130,45 @@ class TestPolyField(object):
         assert not errors
         assert data == original
 
-    def test_deserailize_polyfield_none_required(self):
+    @with_all(
+        ContrivedShapeClassSchema,
+        ContrivedShapeSubclassSchema,
+    )
+    def test_deserailize_polyfield_none_required(self, schema):
         with pytest.raises(ValidationError):
-            self.ContrivedShapeClassSchema(strict=True).load(
+            schema(strict=True).load(
                 {'main': None,
                  'others': None}
             )
 
-    def test_deserialize_polyfield_invalid(self):
+    @with_all(
+        ContrivedShapeClassSchema,
+        ContrivedShapeSubclassSchema,
+    )
+    def test_deserialize_polyfield_invalid(self, schema):
         with pytest.raises(ValidationError):
-            self.ContrivedShapeClassSchema(strict=True).load(
+            schema(strict=True).load(
                 {'main': {'color': 'blue', 'something': 4},
                  'others': None}
             )
 
-    def test_deserialize_polyfield_invalid_schema_returned_is_invalid(self):
+    @with_all(
+        BadContrivedClassSchema,
+        BadContrivedSubclassSchema,
+    )
+    def test_deserialize_polyfield_invalid_schema_returned_is_invalid(self, schema):
         with pytest.raises(ValidationError):
-            self.BadContrivedClassSchema(strict=True).load(
+            schema(strict=True).load(
                 {'main': {'color': 'blue', 'something': 4},
                  'others': None}
             )
 
-    def test_deserialize_polyfield_errors(self):
-        data, errors = self.ContrivedShapeClassSchema().load(
+    @with_all(
+        ContrivedShapeClassSchema,
+        ContrivedShapeSubclassSchema,
+    )
+    def test_deserialize_polyfield_errors(self, schema):
+        data, errors = schema().load(
             {'main': {'color': 'blue', 'length': 'four', 'width': 4},
              'others': None}
         )
@@ -156,14 +208,31 @@ class TestPolyFieldDisambiguationByProperty(object):
                 data.get('type')
             )
 
-    def test_deserialize_polyfield(self):
+    class ContrivedShapeSubclassSchema(Schema):
+        main = ShapePropertyPolyField(required=True)
+        others = ShapePropertyPolyField(allow_none=True, many=True)
+        type = fields.String(required=True)
+
+        @post_load
+        def make_object(self, data):
+            return TestPolyFieldDisambiguationByProperty.ContrivedShapeClass(
+                data.get('main'),
+                data.get('others'),
+                data.get('type')
+            )
+
+    @with_all(
+        ContrivedShapeClassSchema,
+        ContrivedShapeSubclassSchema,
+    )
+    def test_deserialize_polyfield(self, schema):
         original = self.ContrivedShapeClass(
             Rectangle('blue', 1, 100),
             [Rectangle('pink', 4, 93)],
             'rectangle'
         )
 
-        data, errors = self.ContrivedShapeClassSchema(strict=True).load(
+        data, errors = schema(strict=True).load(
             {'main': {'color': 'blue',
                       'length': 1,
                       'width': 100},

--- a/tests/test_polyfield_base.py
+++ b/tests/test_polyfield_base.py
@@ -1,0 +1,26 @@
+from marshmallow_polyfield.polyfield import PolyFieldBase
+
+
+class TrivialExample(PolyFieldBase):
+    def serialization_schema_selector(self, value, obj):
+        super(TrivialExample, self).serialization_schema_selector(value, obj)
+
+    def deserialization_schema_selector(self, value, obj):
+        super(TrivialExample, self).deserialization_schema_selector(value, obj)
+
+
+def test_polyfield_base():
+    te = TrivialExample()
+    try:
+        te.serialization_schema_selector(None, None)
+    except NotImplementedError:
+        pass
+    else:
+        assert False, 'expected to raise'
+
+    try:
+        te.deserialization_schema_selector(None, None)
+    except NotImplementedError:
+        pass
+    else:
+        assert False, 'expected to raise'

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -6,10 +6,19 @@ from tests.shapes import (
     Rectangle,
     Triangle,
     shape_schema_serialization_disambiguation,
-    shape_property_schema_serialization_disambiguation,
     shape_schema_deserialization_disambiguation,
-    shape_property_schema_deserialization_disambiguation
 )
+from tests.polyclasses import ShapePolyField, with_all
+
+
+def with_both_shapes(func):
+    return with_all(
+        PolyField(
+            serialization_schema_selector=shape_schema_serialization_disambiguation,
+            deserialization_schema_selector=shape_schema_deserialization_disambiguation
+        ),
+        ShapePolyField()
+    )(func)
 
 
 def test_serializing_named_tuple():
@@ -35,41 +44,38 @@ def test_serializing_named_tuple_with_meta():
     assert serialized.data['y'] == 2
 
 
-def test_serializing_polyfield_rectangle():
+@with_both_shapes
+def test_serializing_polyfield_rectangle(field):
     rect = Rectangle("blue", 4, 10)
     Sticker = namedtuple('Sticker', ['shape', 'image'])
     marshmallow_sticker = Sticker(rect, "marshmallow.png")
-    field = PolyField(
-        serialization_schema_selector=shape_schema_serialization_disambiguation,
-        deserialization_schema_selector=shape_schema_deserialization_disambiguation
-    )
     rect_dict = field.serialize('shape', marshmallow_sticker)
 
     assert rect_dict == {"length": 4, "width": 10, "color": "blue"}
 
 
-def test_serializing_polyfield_None():
+@with_both_shapes
+def test_serializing_polyfield_None(field):
     Sticker = namedtuple('Sticker', ['shape', 'image'])
     marshmallow_sticker = Sticker(None, "marshmallow.png")
-    field = PolyField(
-        serialization_schema_selector=shape_schema_serialization_disambiguation,
-        deserialization_schema_selector=shape_schema_deserialization_disambiguation
-    )
     rect_dict = field.serialize('shape', marshmallow_sticker)
 
     assert rect_dict is None
 
 
-def test_serializing_polyfield_many():
+@with_all(
+    PolyField(
+        serialization_schema_selector=shape_schema_serialization_disambiguation,
+        deserialization_schema_selector=shape_schema_deserialization_disambiguation,
+        many=True
+    ),
+    ShapePolyField(many=True)
+)
+def test_serializing_polyfield_many(field):
     rect = Rectangle("blue", 4, 10)
     tri = Triangle("red", 1, 100)
     StickerCollection = namedtuple('StickerCollection', ['shapes', 'image'])
     marshmallow_sticker_collection = StickerCollection([rect, tri], "marshmallow.png")
-    field = PolyField(
-        serialization_schema_selector=shape_schema_serialization_disambiguation,
-        deserialization_schema_selector=shape_schema_deserialization_disambiguation,
-        many=True
-    )
     shapes = field.serialize('shapes', marshmallow_sticker_collection)
     expected_shapes = [
         {"length": 4, "width": 10, "color": "blue"},
@@ -78,24 +84,18 @@ def test_serializing_polyfield_many():
     assert shapes == expected_shapes
 
 
-def test_invalid_polyfield():
+@with_both_shapes
+def test_invalid_polyfield(field):
     Sticker = namedtuple('Sticker', ['shape', 'image'])
     with pytest.raises(TypeError):
-        field = PolyField(
-            serialization_schema_selector=shape_schema_serialization_disambiguation,
-            deserialization_schema_selector=shape_schema_deserialization_disambiguation
-        )
         field.serialize('shape', Sticker(3, 3))
 
 
-def test_serializing_polyfield_by_parent_type():
+@with_both_shapes
+def test_serializing_polyfield_by_parent_type(field):
     rect = Rectangle("blue", 4, 10)
     Sticker = namedtuple('Sticker', ['shape', 'image', 'type'])
     marshmallow_sticker = Sticker(rect, "marshmallow.png", 'rectangle')
-    field = PolyField(
-        serialization_schema_selector=shape_property_schema_serialization_disambiguation,
-        deserialization_schema_selector=shape_property_schema_deserialization_disambiguation
-    )
     rect_dict = field.serialize('shape', marshmallow_sticker)
 
     assert rect_dict == {"length": 4, "width": 10, "color": "blue"}

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -40,8 +40,8 @@ def test_serializing_named_tuple_with_meta():
             fields = ('x', 'y')
 
     serialized = PointSerializer().dump(p)
-    assert serialized['x'] == 4
-    assert serialized['y'] == 2
+    assert serialized.data['x'] == 4
+    assert serialized.data['y'] == 2
 
 
 @with_both_shapes

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py33,py34,pypy
+envlist=py27,py36,pypy
 [testenv]
 deps=
   -rrequirements.txt


### PR DESCRIPTION
**NOTE** This change supports `marshmallow~=2.0` and `marshmallow-polyfield~=3.0` and I originally branched off of 35cf134da9042b8c84cd693653b126dc23cce778

I didn't like the interface of having to construct instances of PolyField by passing functions to the constructor. This change adds a new base class PolyFieldBase which PolyField is a subclass of. Users can use the old method of passing arguments to the constructor of PolyField or by subclassing PolyFieldBase which is an ABC with abstract methods of serialization_schema_selector and deserialization_schema_selector.

I also updated the unit tests to test the old way and the new way of constructing PolyField instances.