### PR TITLE
Fix deserialization by property with many=True

### DIFF
--- a/marshmallow_polyfield/polyfield.py
+++ b/marshmallow_polyfield/polyfield.py
@@ -10,7 +10,7 @@ class PolyFieldBase(with_metaclass(abc.ABCMeta, Field)):
         super(PolyFieldBase, self).__init__(**metadata)
         self.many = many
 
-    def _deserialize(self, value, attr, data):
+    def _deserialize(self, value, attr, parent):
         if not self.many:
             value = [value]
 
@@ -18,7 +18,7 @@ class PolyFieldBase(with_metaclass(abc.ABCMeta, Field)):
         for v in value:
             deserializer = None
             try:
-                deserializer = self.deserialization_schema_selector(v, data)
+                deserializer = self.deserialization_schema_selector(v, parent)
                 if isinstance(deserializer, type):
                     deserializer = deserializer()
                 if not isinstance(deserializer, (Field, Schema)):
@@ -40,7 +40,7 @@ class PolyFieldBase(with_metaclass(abc.ABCMeta, Field)):
 
             # Will raise ValidationError if any problems
             if isinstance(deserializer, Field):
-                data = deserializer.deserialize(v, attr, data)
+                data = deserializer.deserialize(v, attr, parent)
             else:
                 deserializer.context.update(getattr(self, 'context', {}))
                 data = deserializer.load(v)

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -243,7 +243,7 @@ class TestPolyFieldDisambiguationByProperty(object):
     def test_deserialize_polyfield(self, schema):
         original = self.ContrivedShapeClass(
             Rectangle('blue', 1, 100),
-            [Rectangle('pink', 4, 93)],
+            [Rectangle('pink', 4, 93), Rectangle('red', 3, 90)],
             'rectangle'
         )
 
@@ -251,9 +251,13 @@ class TestPolyFieldDisambiguationByProperty(object):
             {'main': {'color': 'blue',
                       'length': 1,
                       'width': 100},
-             'others': [{'color': 'pink',
-                         'length': 4,
-                         'width': 93}],
+             'others': [
+                 {'color': 'pink',
+                  'length': 4,
+                  'width': 93},
+                 {'color': 'red',
+                  'length': 3,
+                  'width': 90}],
              'type': 'rectangle'}
         )
         assert data == original


### PR DESCRIPTION
Because data was overridden late in the _deserialize function it didn't preserve the parent object  for subsequent elements and passed along the previous list element instead.

I've fixed the function and amended the deserialize test to have more than 1 element in the list.