### PR TITLE
allow custom TypeError and ValidationError in disamgibuators

### DIFF
--- a/marshmallow_polyfield/polyfield.py
+++ b/marshmallow_polyfield/polyfield.py
@@ -25,7 +25,7 @@ class PolyFieldBase(with_metaclass(abc.ABCMeta, Field)):
                     raise TypeError('Invalid deserializer type')
             except TypeError as te:
                 raise_from(ValidationError(str(te)), te)
-            except ValidationError as ve:
+            except ValidationError:
                 raise
             except Exception as err:
                 class_type = None

--- a/marshmallow_polyfield/polyfield.py
+++ b/marshmallow_polyfield/polyfield.py
@@ -23,6 +23,10 @@ class PolyFieldBase(with_metaclass(abc.ABCMeta, Field)):
                     deserializer = deserializer()
                 if not isinstance(deserializer, (Field, Schema)):
                     raise TypeError('Invalid deserializer type')
+            except TypeError as te:
+                raise_from(ValidationError(str(te)), te)
+            except ValidationError as ve:
+                raise
             except Exception as err:
                 class_type = None
                 if deserializer:

--- a/marshmallow_polyfield/polyfield.py
+++ b/marshmallow_polyfield/polyfield.py
@@ -22,7 +22,7 @@ class PolyFieldBase(with_metaclass(abc.ABCMeta, Field)):
                 if isinstance(deserializer, type):
                     deserializer = deserializer()
                 if not isinstance(deserializer, (Field, Schema)):
-                    raise TypeError('Invalid deserializer type')
+                    raise Exception('Invalid deserializer type')
             except TypeError as te:
                 raise_from(ValidationError(str(te)), te)
             except ValidationError:

--- a/tests/shapes.py
+++ b/tests/shapes.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 import six
-from marshmallow import Schema, fields, post_load
+from marshmallow import Schema, fields, post_load, ValidationError
 
 
 class Shape(object):
@@ -91,8 +91,12 @@ def shape_property_schema_serialization_disambiguation(base_object, obj):
 
 def shape_schema_deserialization_disambiguation(object_dict, _):
     if object_dict.get("base"):
+        if object_dict.get("base") < 0:
+            raise ValidationError("Base cannot be negative.")
         return TriangleSchema()
     elif object_dict.get("length"):
+        if object_dict.get("length") < 0:
+            raise Exception("Bad Case")
         return RectangleSchema()
 
     raise TypeError("Could not detect type. "

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -159,8 +159,8 @@ class TestPolyField(object):
             )
 
         assert str(excinfo.value) == str("{'main': ['Could not detect type. "
-                                     "Did not have a base or a length. "
-                                     "Are you sure this is a shape?']}")
+                                         "Did not have a base or a length. "
+                                         "Are you sure this is a shape?']}")
 
     @with_all(
         ContrivedShapeClassSchema,
@@ -180,7 +180,8 @@ class TestPolyField(object):
         ContrivedShapeSubclassSchema,
     )
     def test_deserialize_polyfield_invalid_generic_error(self, schema):
-        with pytest.raises(ValidationError, match='Ensure there is a deserialization_schema_selector'):
+        err_msg = 'Ensure there is a deserialization_schema_selector'
+        with pytest.raises(ValidationError, match=err_msg):
             schema().load(
                 {'main': {'width': 100, 'length': -1},
                  'others': {'width': 100, 'length': 10}}

--- a/tests/test_deserialization.py
+++ b/tests/test_deserialization.py
@@ -151,11 +151,40 @@ class TestPolyField(object):
         ContrivedShapeClassSchema,
         ContrivedShapeSubclassSchema,
     )
-    def test_deserialize_polyfield_invalid(self, schema):
-        with pytest.raises(ValidationError):
+    def test_deserialize_polyfield_invalid_type_error(self, schema):
+        with pytest.raises(ValidationError) as excinfo:
             schema().load(
                 {'main': {'color': 'blue', 'something': 4},
                  'others': None}
+            )
+
+        assert str(excinfo.value) == str("{'main': ['Could not detect type. "
+                                     "Did not have a base or a length. "
+                                     "Are you sure this is a shape?']}")
+
+    @with_all(
+        ContrivedShapeClassSchema,
+        ContrivedShapeSubclassSchema,
+    )
+    def test_deserialize_polyfield_invalid_validation_error(self, schema):
+        with pytest.raises(ValidationError) as excinfo:
+            schema().load(
+                {'main': {'base': -1, 'something': 4},
+                 'others': None}
+            )
+
+        assert str(excinfo.value) == "{'main': ['Base cannot be negative.']}"
+
+    @with_all(
+        ContrivedShapeClassSchema,
+        ContrivedShapeSubclassSchema,
+    )
+    def test_deserialize_polyfield_invalid_generic_error(self, schema):
+        with pytest.raises(ValidationError, match='Ensure there is a deserialization_schema_selector'):
+            schema().load(
+                {'main': {'width': 100, 'length': -1},
+                 'others': {'width': 100, 'length': 10}}
+
             )
 
     @with_all(


### PR DESCRIPTION
Attempt to address the issues raised in https://github.com/Bachmann1234/marshmallow-polyfield/issues/7.

- `TypeError`'s raised in the deserialization disambiguation will be re-raised with the same error message as a `ValidationError`
- `ValidationError`'s raised in the deserialization disambiguation will be raised as is 
- Any other `Exception` will be re-raised as a `ValidationException` using the `"Unable to use schema..."` messaging that is currently in place