### PR TITLE
Drop Python 2 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,11 @@ language: python
 sudo: false
 matrix:
   include:
-  - python: '2.7'
+  - python: '3.5'
   - python: '3.6'
   - python: '3.7'
-  - python: pypy
+  - python: '3.8'
+  - python: pypy3
     dist: trusty
 before_install:
 - pip install -U pip

--- a/marshmallow_polyfield/polyfield.py
+++ b/marshmallow_polyfield/polyfield.py
@@ -1,11 +1,10 @@
 import abc
-from six import raise_from, with_metaclass
 
 from marshmallow import Schema, ValidationError
 from marshmallow.fields import Field
 
 
-class PolyFieldBase(with_metaclass(abc.ABCMeta, Field)):
+class PolyFieldBase(Field, metaclass=abc.ABCMeta):
     def __init__(self, many=False, **metadata):
         super(PolyFieldBase, self).__init__(**metadata)
         self.many = many
@@ -24,7 +23,7 @@ class PolyFieldBase(with_metaclass(abc.ABCMeta, Field)):
                 if not isinstance(deserializer, (Field, Schema)):
                     raise Exception('Invalid deserializer type')
             except TypeError as te:
-                raise_from(ValidationError(str(te)), te)
+                raise ValidationError(str(te)) from te
             except ValidationError:
                 raise
             except Exception as err:
@@ -32,20 +31,17 @@ class PolyFieldBase(with_metaclass(abc.ABCMeta, Field)):
                 if deserializer:
                     class_type = str(type(deserializer))
 
-                raise_from(
-                    ValidationError(
-                        "Unable to use schema. Error: {err}\n"
-                        "Ensure there is a deserialization_schema_selector"
-                        " and then it returns a field or a schema when the function is passed in "
-                        "{value_passed}. This is the class I got. "
-                        "Make sure it is a field or a schema: {class_type}".format(
-                            err=err,
-                            value_passed=v,
-                            class_type=class_type
-                        )
-                    ),
-                    err
-                )
+                raise ValidationError(
+                    "Unable to use schema. Error: {err}\n"
+                    "Ensure there is a deserialization_schema_selector"
+                    " and then it returns a field or a schema when the function is passed in "
+                    "{value_passed}. This is the class I got. "
+                    "Make sure it is a field or a schema: {class_type}".format(
+                        err=err,
+                        value_passed=v,
+                        class_type=class_type
+                    )
+                ) from err
 
             # Will raise ValidationError if any problems
             if isinstance(deserializer, Field):

--- a/marshmallow_polyfield/polyfield.py
+++ b/marshmallow_polyfield/polyfield.py
@@ -6,7 +6,7 @@ from marshmallow.fields import Field
 
 class PolyFieldBase(Field, metaclass=abc.ABCMeta):
     def __init__(self, many=False, **metadata):
-        super(PolyFieldBase, self).__init__(**metadata)
+        super().__init__(**metadata)
         self.many = many
 
     def _deserialize(self, value, attr, parent, **kwargs):
@@ -112,7 +112,7 @@ class PolyField(PolyFieldBase):
         and returns the appropriate schema
 
         """
-        super(PolyField, self).__init__(many=many, **metadata)
+        super().__init__(many=many, **metadata)
         self._serialization_schema_selector_arg = serialization_schema_selector
         self._deserialization_schema_selector_arg = deserialization_schema_selector
 

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,8 @@ setup(
     license='Apache 2.0',
     keywords=['serialization', 'rest', 'json', 'api', 'marshal',
               'marshalling', 'deserialization', 'validation', 'schema'],
-    install_requires=['marshmallow>=3.0.0b10', 'six'],
+    python_requires='>=3.5',
+    install_requires=['marshmallow>=3.0.0b10'],
     classifiers=[
         'Intended Audience :: Developers',
         'License :: OSI Approved :: Apache Software License',

--- a/tests/shapes.py
+++ b/tests/shapes.py
@@ -19,7 +19,7 @@ class ShapeSchema(Schema):
 
 class Triangle(Shape):
     def __init__(self, color, base, height):
-        super(Triangle, self).__init__(color)
+        super().__init__(color)
         self.base = base
         self.height = height
 
@@ -39,7 +39,7 @@ class TriangleSchema(ShapeSchema):
 
 class Rectangle(Shape):
     def __init__(self, color, length, width):
-        super(Rectangle, self).__init__(color)
+        super().__init__(color)
         self.length = length
         self.width = width
 

--- a/tests/shapes.py
+++ b/tests/shapes.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-import six
 from marshmallow import Schema, fields, post_load, ValidationError
 
 
@@ -123,7 +121,7 @@ def shape_property_schema_deserialization_disambiguation(object_dict, data):
 def fuzzy_schema_deserialization_disambiguation(data, _):
     if isinstance(data, dict):
         return ShapeSchema
-    if isinstance(data, six.string_types):
+    if isinstance(data, str):
         return fields.Email
 
     raise TypeError('Could not detect type. '

--- a/tests/test_polyfield_base.py
+++ b/tests/test_polyfield_base.py
@@ -3,10 +3,10 @@ from marshmallow_polyfield.polyfield import PolyFieldBase
 
 class TrivialExample(PolyFieldBase):
     def serialization_schema_selector(self, value, obj):
-        super(TrivialExample, self).serialization_schema_selector(value, obj)
+        super().serialization_schema_selector(value, obj)
 
     def deserialization_schema_selector(self, value, obj):
-        super(TrivialExample, self).deserialization_schema_selector(value, obj)
+        super().deserialization_schema_selector(value, obj)
 
 
 def test_polyfield_base():

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist=py27,py36,py37,pypy
+envlist=py35,py36,py37,py38,pypy3
 [testenv]
 deps=
   -rrequirements.txt


### PR DESCRIPTION
Polyfield depends on Marshmallow 3 which requires at least Python 3.5.

Bachmann1234/marshmallow-polyfield#35