### PR TITLE
Include tests in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include *.rst LICENSE
+recursive-include tests *.py


### PR DESCRIPTION
This PR suggests updating `MANIFEST.in` in order to include the `tests/` directory in the source sdist. By including them in the `.tar.gz`, downstream packagers would be able to execute the tests to verify the package by using only the `pypi`-distributed files - (actually, this is a wishlist item coming from an effort for packaging `marshmallow-polyfield` in Debian, for making things easier :)).